### PR TITLE
Fixed loadstring loading to the wrong _G

### DIFF
--- a/src/lua/bios.lua
+++ b/src/lua/bios.lua
@@ -329,6 +329,15 @@ function read( _sReplaceChar, _tHistory )
 	return sLine
 end
 
+local ls = loadstring
+loadstring = function(str, source)
+	local f, err = ls(str, source)
+	if f then
+		setfenv(f, setmetatable({}, {__index=_G}))
+	end
+	return f, err
+end
+
 loadfile = function( _sFile )
 	local file = fs.open( _sFile, "r" )
 	if file then


### PR DESCRIPTION
Not sure if you're using a modified bios.lua, but it needs to be modified for proper loadstring behavior.
