### PR TITLE
Fixed changes to global being persistent across reboots

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -73,7 +73,7 @@ function Emulator:start()
 
 	local fn, err = love.filesystem.load('lua/bios.lua') -- lua/bios.lua
 	local tEnv = {}
-	api.env._G = api.env
+	
 	if not fn then
 		print(err)
 		return


### PR DESCRIPTION
Tooks some messing around, and a new local term variable instead of
replacing api.term on api.init(), but moving api.env = {...} into
api.init() solved the issue where changes in _G from in the emulator
would remain after a reboot.
